### PR TITLE
Zk get location fix

### DIFF
--- a/controllers/geocode.js
+++ b/controllers/geocode.js
@@ -20,9 +20,10 @@ module.exports = function (userCoordinates, callback) {
 
     for (var i = 0; i < response.json.results.length; i++) {
       if (response.json.results[i].types[0] == 'postal_code') {
-        console.log(response.json.results[i].short_name);
+
         innerObject = response.json.results[i].address_components;
         address = innerObject[0].long_name;
+        break;
       }
     }
 

--- a/controllers/geocode.js
+++ b/controllers/geocode.js
@@ -1,28 +1,34 @@
 
 const util = require('util')
 
-module.exports = function(userCoordinates,callback) {
+module.exports = function (userCoordinates, callback) {
 
-var googleMapsClient = require('@google/maps').createClient({
+  var googleMapsClient = require('@google/maps').createClient({
     // key: process.env.GOOGLE_KEY
     key: 'AIzaSyBAhNxc8BbsIMC5tFTNUSADF8vhSiNxXmA'
   });
 
-var latLngString = (userCoordinates.lat).toString() + "," + (userCoordinates.lng).toString();
+  var latLngString = (userCoordinates.lat).toString() + "," + (userCoordinates.lng).toString();
 
-// Reverse Geocode an address.
-googleMapsClient.geocode({
-  address: latLngString
-}, function (err, response) {
-  
-  console.log(util.inspect(response.json.results, false, null))
+  // Reverse Geocode an address.
+  googleMapsClient.geocode({
+    address: latLngString
+  }, function (err, response) {
 
-  //Get Vague, but accurate address from Google API response
-  var address = response.json.results[4].formatted_address;
+    //console.log(util.inspect(response.json.results, false, null))
+    var address = 0;
 
-  //Send Address back to Index page
-  callback(address);
-  
-});
+    for (var i = 0; i < response.json.results.length; i++) {
+      if (response.json.results[i].types[0] == 'postal_code') {
+        console.log(response.json.results[i].short_name);
+        innerObject = response.json.results[i].address_components;
+        address = innerObject[0].long_name;
+      }
+    }
+
+    //Send Address back to Index page
+    callback(address);
+
+  });
 
 }


### PR DESCRIPTION
Updated the Get Location button to only pull Zipcode from google object.  Revised backend code to parse the google object looking for postal code string first to hopefully get better results.